### PR TITLE
Changed sparql route from absolute to relative url

### DIFF
--- a/dati-semantic-frontend/deploymentConfig.yaml
+++ b/dati-semantic-frontend/deploymentConfig.yaml
@@ -71,7 +71,7 @@ spec:
             - name: API_URL
               value: /api
             - name: SPARQL_ENDPOINT_URL
-              value: https://www.schema.gov.it/sparql
+              value: /sparql
             - name: MATOMO_SITE_ID
               value: "33"
       restartPolicy: Always


### PR DESCRIPTION
## Description

This PR does:

1. Change value of variable SPARQL_ENDPOINT_URL from an abosule URL to a relative URL.
With this change, the browser automatically redirect the user on the same host of the application.
Ex:
If the user is on https://schema.gov.it he will be ridericet to  https://schema.gov.it/sparql 

Fixes #12

cc: @CreaIstat 