### PR TITLE
WebVowl- removed unused environment variables

### DIFF
--- a/dati-semantic-webvowl/deploymentConfig.yaml
+++ b/dati-semantic-webvowl/deploymentConfig.yaml
@@ -67,11 +67,6 @@ spec:
           terminationMessagePolicy: File
           image: >-
             ghcr.io/teamdigitale/dati-semantic-webvowl:20221122-1-772a9d1
-          env:
-            - name: EXTERNAL_URL
-              value: "https://lode-ndc-test.apps.cloudpub.testedev.istat.it/lode"
-            # - name: MATOMO_SITE_ID  # FIXME
-            #   value: "35"
       restartPolicy: Always
       terminationGracePeriodSeconds: 75
       dnsPolicy: ClusterFirst


### PR DESCRIPTION
This PR does:

1. remove unused environmet variables from file dati-semantic-webvowl/deploymentConfig.yaml

cc: @CreaIstat 