### PR TITLE
Alligned docker images

### DIFF
--- a/dati-semantic-lode/deploymentConfig.yaml
+++ b/dati-semantic-lode/deploymentConfig.yaml
@@ -66,7 +66,7 @@ spec:
           imagePullPolicy: Always
           terminationMessagePolicy: File
           image: >-
-            ghcr.io/teamdigitale/lode:20221123-13-7a96e19
+            ghcr.io/teamdigitale/dati-semantic-lode:20221128-14-7db975f
           env:
             - name: EXTERNAL_URL
               value: "https://lode-ndc-test.apps.cloudpub.testedev.istat.it/lode"

--- a/dati-semantic-webvowl/deploymentConfig.yaml
+++ b/dati-semantic-webvowl/deploymentConfig.yaml
@@ -66,7 +66,7 @@ spec:
           imagePullPolicy: Always
           terminationMessagePolicy: File
           image: >-
-            ghcr.io/teamdigitale/dati-semantic-webvowl:20221122-1-772a9d1
+            ghcr.io/teamdigitale/dati-semantic-webvowl:20221124-8-f196be9
       restartPolicy: Always
       terminationGracePeriodSeconds: 75
       dnsPolicy: ClusterFirst


### PR DESCRIPTION
This PR does:

1. Alligned docker images for "dati-semantic-lode" and "dati-semantic-webvowl"

cc: @CreaIstat 