### PR TITLE
Added env variabile WEBVOWL_URL for lode service

### DIFF
--- a/dati-semantic-lode/deploymentConfig.yaml
+++ b/dati-semantic-lode/deploymentConfig.yaml
@@ -70,6 +70,8 @@ spec:
           env:
             - name: EXTERNAL_URL
               value: "https://lode-ndc-dev.apps.cloudpub.testedev.istat.it/lode"
+            - name: WEBVOWL_URL
+              value: "https://webvowl-ndc-dev.apps.cloudpub.testedev.istat.it"
               # - name: MATOMO_SITE_ID  # FIXME
               #   value: "35"
       restartPolicy: Always


### PR DESCRIPTION
This PR does : 
1 - add environment variable WEBVOWL_URL for dati-semantic-lode service, this permit to visualize the ontologies on webvowl visualizer