### PR TITLE
Fix env variabile WEBVOWL_URL for lode service

### DIFF
--- a/dati-semantic-lode/deploymentConfig.yaml
+++ b/dati-semantic-lode/deploymentConfig.yaml
@@ -71,7 +71,7 @@ spec:
             - name: EXTERNAL_URL
               value: "https://lode-ndc-dev.apps.cloudpub.testedev.istat.it/lode"
             - name: WEBVOWL_URL
-              value: "https://webvowl-ndc-dev.apps.cloudpub.testedev.istat.it"
+              value: "https://webvowl-ndc-dev.apps.cloudpub.testedev.istat.it/#iri="
               # - name: MATOMO_SITE_ID  # FIXME
               #   value: "35"
       restartPolicy: Always


### PR DESCRIPTION
This PR does:
1 - fix value of environment variable WEBVOWL_URL for dati-semantic-lode