### PR TITLE
Deploy the Schema Editor on Kubernetes.

### DIFF
--- a/dati-semantic-schema-editor/autoscaling.yaml
+++ b/dati-semantic-schema-editor/autoscaling.yaml
@@ -1,0 +1,19 @@
+kind: HorizontalPodAutoscaler
+apiVersion: autoscaling/v2beta2
+metadata:
+  name: autoscaling-dati-semantic-schema-editor
+  namespace: ndc-dev
+spec:
+  scaleTargetRef:
+    kind: Deployment
+    name: dati-semantic-schema-editor
+    apiVersion: apps.openshift.io/v1
+  minReplicas: 1
+  maxReplicas: 2
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80

--- a/dati-semantic-schema-editor/configmap.yaml
+++ b/dati-semantic-schema-editor/configmap.yaml
@@ -1,0 +1,9 @@
+#
+# The Schema Editor configuration containing
+#   the references to the triplestore and other settings.
+#
+# kind: ConfigMap
+# apiVersion: v1
+# metadata:
+#   name: configmap-schema-editor
+#   namespace: ndc-dev

--- a/dati-semantic-schema-editor/deployment.yaml
+++ b/dati-semantic-schema-editor/deployment.yaml
@@ -1,0 +1,51 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: dati-semantic-schema-editor
+  name: dati-semantic-schema-editor
+  namespace: ndc-dev
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: dati-semantic-schema-editor
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: dati-semantic-schema-editor
+      name: dati-semantic-schema-editor
+    spec:
+      containers:
+        - image: ghcr.io/teamdigitale/dati-semantic-schema-editor:20251006-10-05b2592
+          imagePullPolicy: Always
+          name: dati-semantic-schema-editor
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+          #
+          # This is a static nginx server, so it
+          #   does not need much resources.
+          #
+          resources:
+            limits:
+              cpu: 500m
+              memory: 1024Mi
+            requests:
+              cpu: 250m
+              memory: 512Mi
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: { }
+      terminationGracePeriodSeconds: 75

--- a/dati-semantic-schema-editor/imagestream.yaml
+++ b/dati-semantic-schema-editor/imagestream.yaml
@@ -1,0 +1,10 @@
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  name: dati-semantic-schema-editor
+  namespace: ndc-dev
+  labels:
+    application: dati-semantic-schema-editor
+spec:
+  lookupPolicy:
+    local: false

--- a/dati-semantic-schema-editor/route.yaml
+++ b/dati-semantic-schema-editor/route.yaml
@@ -1,0 +1,19 @@
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: dati-semantic-schema-editor
+  namespace: ndc-dev
+  labels:
+    application: dati-semantic-schema-editor
+spec:
+  host: schema-editor-ndc-dev.apps.cloudpub.testedev.istat.it
+  to:
+    kind: Service
+    name: dati-semantic-schema-editor
+    weight: 100
+  port:
+    targetPort: 8080
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+  wildcardPolicy: None  

--- a/dati-semantic-schema-editor/service.yaml
+++ b/dati-semantic-schema-editor/service.yaml
@@ -1,0 +1,15 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: dati-semantic-schema-editor
+  namespace: ndc-dev
+  labels:
+    app: dati-semantic-schema-editor
+spec:
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080
+  selector:
+    app: dati-semantic-schema-editor
+  sessionAffinity: None


### PR DESCRIPTION
## This PR

- [x] deploys the schema editor on kubernetes
- [x] uses the default configuration of the application 
- [x] references the existing build          
- [x] registers the following route: `schema-editor-ndc-dev.apps.cloudpub.testedev.istat.it`
- [x] contacts the container port `8000` used by the unprivileged nginx image
          
## Notes

This may require some tweaks related to the target infrastructure.