### PR TITLE
Fix: #286. Updated image, env variables and route config

### DIFF
--- a/dati-semantic-schema-editor-api/configmap.yaml
+++ b/dati-semantic-schema-editor-api/configmap.yaml
@@ -15,3 +15,5 @@ data:
   SPARQL_URL: "https://virtuoso-test-external-service-ndc-test.apps.cloudpub.testedev.istat.it/sparql"
   PORT: "8080"
   CORS_ORIGIN: "*"
+  SERVER_URL: "https://schema-editor-api-ndc-dev.apps.cloudpub.testedev.istat.it"
+  GLOBAL_PREFIX: "semantic-tool/api"

--- a/dati-semantic-schema-editor-api/deployment.yaml
+++ b/dati-semantic-schema-editor-api/deployment.yaml
@@ -34,7 +34,7 @@ spec:
           emptyDir:
             sizeLimit: 100Mi
       containers:
-        - image: ghcr.io/teamdigitale/dati-semantic-schema-editor-api:0.1.0
+        - image: ghcr.io/teamdigitale/dati-semantic-schema-editor-api:20260319-205-9539adb
           imagePullPolicy: Always
           name: dati-semantic-schema-editor-api
           # Load configuration variables from the ConfigMap.

--- a/dati-semantic-schema-editor-api/route.yaml
+++ b/dati-semantic-schema-editor-api/route.yaml
@@ -18,4 +18,5 @@ spec:
     termination: edge
     insecureEdgeTerminationPolicy: Redirect
   wildcardPolicy: None
-status: {}
+status:
+  ingress: []

--- a/dati-semantic-schema-editor-api/route.yaml
+++ b/dati-semantic-schema-editor-api/route.yaml
@@ -7,6 +7,7 @@ metadata:
     application: dati-semantic-schema-editor-api
 spec:
   host: schema-editor-api-ndc-dev.apps.cloudpub.testedev.istat.it
+  path: /semantic-tool
   to:
     kind: Service
     name: dati-semantic-schema-editor-api


### PR DESCRIPTION
Updated env variables and route config to serve content with a global prefix
Updated image to the latest development image for test only purpose