### PR TITLE
Fix: #290. Schema editor API for PDND

### DIFF
--- a/.github/workflows/update-schema-editor-images.yaml
+++ b/.github/workflows/update-schema-editor-images.yaml
@@ -30,6 +30,10 @@ jobs:
             image: ghcr.io/teamdigitale/dati-semantic-schema-editor-api
             branch_name: update/schema-editor-api-image
             target_file: dati-semantic-schema-editor-api/deployment.yaml
+          - title: Update Schema Editor API PDND docker image
+            image: ghcr.io/teamdigitale/dati-semantic-schema-editor-api
+            branch_name: update/schema-editor-api-pdnd-image
+            target_file: dati-semantic-schema-editor-api-pdnd/deployment.yaml
 
     steps:
       - name: Checkout dev

--- a/dati-semantic-schema-editor-api-pdnd/autoscaling.yaml
+++ b/dati-semantic-schema-editor-api-pdnd/autoscaling.yaml
@@ -1,0 +1,19 @@
+kind: HorizontalPodAutoscaler
+apiVersion: autoscaling/v2beta2
+metadata:
+  name: autoscaling-dati-semantic-schema-editor-api-pdnd
+  namespace: ndc-dev
+spec:
+  scaleTargetRef:
+    kind: Deployment
+    name: dati-semantic-schema-editor-api-pdnd
+    apiVersion: apps.openshift.io/v1
+  minReplicas: 1
+  maxReplicas: 2
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80

--- a/dati-semantic-schema-editor-api-pdnd/configmap.yaml
+++ b/dati-semantic-schema-editor-api-pdnd/configmap.yaml
@@ -1,0 +1,17 @@
+#
+# The Schema Editor API configuration containing
+#   the references to the triplestore,
+#   the port to listen on, etc.
+#
+# See https://github.com/teamdigitale/dati-semantic-schema-editor
+#  for details.
+#
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: configmap-schema-editor-api-pdnd
+  namespace: ndc-dev
+data:
+  SPARQL_URL: "https://virtuoso-test-external-service-ndc-test.apps.cloudpub.testedev.istat.it/sparql"
+  PORT: "8080"
+  CORS_ORIGIN: "*"

--- a/dati-semantic-schema-editor-api-pdnd/deployment.yaml
+++ b/dati-semantic-schema-editor-api-pdnd/deployment.yaml
@@ -1,0 +1,68 @@
+#
+# Deployment for the Dati Semantic Schema Editor API (PDND)
+#   see: https://github.com/teamdigitale/dati-semantic-schema-editor
+#
+# The configuration is provided via a ConfigMap (configmap-schema-editor-api-pdnd)
+#
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: dati-semantic-schema-editor-api-pdnd
+  name: dati-semantic-schema-editor-api-pdnd
+  namespace: ndc-dev
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: dati-semantic-schema-editor-api-pdnd
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: dati-semantic-schema-editor-api-pdnd
+      name: dati-semantic-schema-editor-api-pdnd
+    spec:
+      volumes:
+        # A small volume for caching temporary files.
+        - name: cache
+          emptyDir:
+            sizeLimit: 100Mi
+      containers:
+        - image: ghcr.io/teamdigitale/dati-semantic-schema-editor-api:0.1.0
+          imagePullPolicy: Always
+          name: dati-semantic-schema-editor-api-pdnd
+          # Load configuration variables from the ConfigMap.
+          #   Future releases may use Secrets.
+          envFrom:
+            - configMapRef:
+                name: configmap-schema-editor-api-pdnd
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+          volumeMounts:
+            - name: cache
+              mountPath: /home/node/
+          #
+          # Monitor resource usage and tweak limits as needed.
+          #
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 1024Mi
+            requests:
+              cpu: 250m
+              memory: 512Mi
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 75

--- a/dati-semantic-schema-editor-api-pdnd/imagestream.yaml
+++ b/dati-semantic-schema-editor-api-pdnd/imagestream.yaml
@@ -1,0 +1,10 @@
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  name: dati-semantic-schema-editor-api-pdnd
+  namespace: ndc-dev
+  labels:
+    application: dati-semantic-schema-editor-api-pdnd
+spec:
+  lookupPolicy:
+    local: false

--- a/dati-semantic-schema-editor-api-pdnd/route.yaml
+++ b/dati-semantic-schema-editor-api-pdnd/route.yaml
@@ -1,0 +1,22 @@
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: dati-semantic-schema-editor-api-pdnd
+  namespace: ndc-dev
+  labels:
+    application: dati-semantic-schema-editor-api-pdnd
+  annotations:
+    haproxy.router.openshift.io/ip_whitelist: 193.204.90.0/23
+spec:
+  host: schema-editor-api-pdnd-ndc-dev.apps.cloudpub.testedev.istat.it
+  to:
+    kind: Service
+    name: dati-semantic-schema-editor-api-pdnd
+    weight: 100
+  port:
+    targetPort: 8080
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+  wildcardPolicy: None
+status: {}

--- a/dati-semantic-schema-editor-api-pdnd/service.yaml
+++ b/dati-semantic-schema-editor-api-pdnd/service.yaml
@@ -1,0 +1,15 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: dati-semantic-schema-editor-api-pdnd
+  namespace: ndc-dev
+  labels:
+    app: dati-semantic-schema-editor-api-pdnd
+spec:
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080
+  selector:
+    app: dati-semantic-schema-editor-api-pdnd
+  sessionAffinity: None


### PR DESCRIPTION
This PR fixes #290 .

- Added a clone of the API in the same namespace called dati-semantic-schema-editor-api-pdnd
- Allowed traffic only from a class of IP adderesses via whitelist