### PR TITLE
Add SERVER_URL and GLOBAL_PREFIX to configmap

### DIFF
--- a/dati-semantic-schema-editor-api-pdnd/configmap.yaml
+++ b/dati-semantic-schema-editor-api-pdnd/configmap.yaml
@@ -15,3 +15,5 @@ data:
   SPARQL_URL: "https://virtuoso-test-external-service-ndc-test.apps.cloudpub.testedev.istat.it/sparql"
   PORT: "8080"
   CORS_ORIGIN: "*"
+  SERVER_URL: "https://schema-editor-api-pdnd-ndc-dev.apps.cloudpub.testedev.istat.it"
+  GLOBAL_PREFIX: "semantic-tool/api"


### PR DESCRIPTION
- Added server_url to generate a correct openapi.yaml file
- Added global prefix explicitly