### PR TITLE
Fix: #300. Persist credentials to allow pushing updates - dev branch

### DIFF
--- a/.github/workflows/update-schema-editor-images.yaml
+++ b/.github/workflows/update-schema-editor-images.yaml
@@ -46,7 +46,7 @@ jobs:
         with:
           ref: dev
           fetch-depth: 0
-          persist-credentials: false
+          persist-credentials: true # Use true to allow the workflow to push to the branches and open PRs
 
       - name: Install yq
         uses: mikefarah/yq@5a7e72a743649b1b3a47d1a1d8214f3453173c51 # v4.52.4


### PR DESCRIPTION
### This PR:

Fixes: #300

### Details:

Restored persist-credentials to allow push of updated images into new branch
Aligns dev branch