### PR TITLE
Update backend and lode images to latest builds

### DIFF
--- a/dati-semantic-backend/deployment.yaml
+++ b/dati-semantic-backend/deployment.yaml
@@ -92,7 +92,7 @@ spec:
               value: "true"
             - name: JAVA_MAIL_DEBUG
               value: "true"
-          image: ghcr.io/teamdigitale/dati-semantic-backend:20260310-536-9d3cb05
+          image: ghcr.io/teamdigitale/dati-semantic-backend:20260414-539-0280f74
           imagePullPolicy: Always
           livenessProbe:
             failureThreshold: 3

--- a/dati-semantic-lode/deployment.yaml
+++ b/dati-semantic-lode/deployment.yaml
@@ -29,7 +29,7 @@ spec:
               value: https://lode-ndc-dev.apps.cloudpub.testedev.istat.it
             - name: WEBVOWL_URL
               value: https://webvowl-ndc-dev.apps.cloudpub.testedev.istat.it/#iri=
-          image: ghcr.io/teamdigitale/dati-semantic-lode:20260217-38-7a671dd
+          image: ghcr.io/teamdigitale/dati-semantic-lode:20260414-42-d55c02c
           imagePullPolicy: Always
           name: dati-semantic-lode
           ports:


### PR DESCRIPTION
## Summary
- Update backend image to `20260414-539-0280f74` (from `20260310-536-9d3cb05`)
- Update lode image to `20260414-42-d55c02c` (from `20260217-38-7a671dd`)

lodview and webvowl already have the latest published images.

## Context
The automated deploy step (`update-config.yaml`) fails with a git push auth error, so these image updates are done manually.