### PR TITLE
fix(csv-apis-data): align metadata.name and labels with dirname

### DIFF
--- a/dati-semantic-csv-apis-data/autoscaling.yaml
+++ b/dati-semantic-csv-apis-data/autoscaling.yaml
@@ -1,12 +1,12 @@
 kind: HorizontalPodAutoscaler
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 metadata:
-  name: autoscaling-dati-semantic-csv-api
+  name: autoscaling-dati-semantic-csv-apis-data
   namespace: ndc-dev
 spec:
   scaleTargetRef:
     kind: Deployment
-    name: dati-semantic-csv-api
+    name: dati-semantic-csv-apis-data
     apiVersion: apps.openshift.io/v1
   minReplicas: 1
   maxReplicas: 2

--- a/dati-semantic-csv-apis-data/deployment.yaml
+++ b/dati-semantic-csv-apis-data/deployment.yaml
@@ -8,15 +8,15 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: dati-semantic-csv-api
-  name: dati-semantic-csv-api
+    app: dati-semantic-csv-apis-data
+  name: dati-semantic-csv-apis-data
   namespace: ndc-dev
 spec:
   replicas: 1
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app: dati-semantic-csv-api
+      app: dati-semantic-csv-apis-data
   strategy:
     rollingUpdate:
       maxSurge: 25%
@@ -25,13 +25,13 @@ spec:
   template:
     metadata:
       labels:
-        app: dati-semantic-csv-api
-      name: dati-semantic-csv-api
+        app: dati-semantic-csv-apis-data
+      name: dati-semantic-csv-apis-data
     spec:
       containers:
         - image: ghcr.io/teamdigitale/dati-semantic-csv-apis-data:0.0.14
           imagePullPolicy: Always
-          name: dati-semantic-csv-api
+          name: dati-semantic-csv-apis-data
           workingDir: /data
           envFrom:
             - configMapRef:

--- a/dati-semantic-csv-apis-data/imagestream.yaml
+++ b/dati-semantic-csv-apis-data/imagestream.yaml
@@ -1,10 +1,10 @@
 kind: ImageStream
 apiVersion: image.openshift.io/v1
 metadata:
-  name: dati-semantic-csv-api
+  name: dati-semantic-csv-apis-data
   namespace: ndc-dev
   labels:
-    application: dati-semantic-csv-api
+    application: dati-semantic-csv-apis-data
 spec:
   lookupPolicy:
     local: false

--- a/dati-semantic-csv-apis-data/route.yaml
+++ b/dati-semantic-csv-apis-data/route.yaml
@@ -1,15 +1,15 @@
 kind: Route
 apiVersion: route.openshift.io/v1
 metadata:
-  name: dati-semantic-csv-api
+  name: dati-semantic-csv-apis-data
   namespace: ndc-dev
   labels:
-    application: dati-semantic-csv-api
+    application: dati-semantic-csv-apis-data
 spec:
   host: vocabularies-api-ndc-dev.apps.cloudpub.testedev.istat.it
   to:
     kind: Service
-    name: dati-semantic-csv-api
+    name: dati-semantic-csv-apis-data
     weight: 100
   port:
     targetPort: 8080

--- a/dati-semantic-csv-apis-data/service.yaml
+++ b/dati-semantic-csv-apis-data/service.yaml
@@ -1,15 +1,15 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: dati-semantic-csv-api
+  name: dati-semantic-csv-apis-data
   namespace: ndc-dev
   labels:
-    app: dati-semantic-csv-api
+    app: dati-semantic-csv-apis-data
 spec:
   ports:
     - protocol: TCP
       port: 8080
       targetPort: 8080
   selector:
-    app: dati-semantic-csv-api
+    app: dati-semantic-csv-apis-data
   sessionAffinity: None


### PR DESCRIPTION
Follow-up to #310.

The previous rename moved the directory but left `metadata.name`, labels and selectors as `dati-semantic-csv-api`. The Tekton `task-skopeo-copy-v1` derives the image tag via `oc get deployment/<dirname>`, so after #310 the lookup returned NotFound and skopeo was invoked with an empty tag:

```
fatal: Invalid source name docker://ghcr.io/teamdigitale/dati-semantic-csv-apis-data:: invalid reference format
```

Changes:
- Rename `metadata.name`, labels, selectors and container name to `dati-semantic-csv-apis-data` in deployment, service, route, imagestream, autoscaling.
- Bump HPA `apiVersion` from `autoscaling/v2beta2` (removed in k8s 1.26+) to `autoscaling/v2`.
- `configmap-csv-api` name left unchanged (still referenced by `envFrom`).
- Route host `vocabularies-api-ndc-dev` left unchanged.

After merge, the old k8s resources (Deployment/Service/Route/ImageStream/HPA named `dati-semantic-csv-api`) in `ndc-dev` should be deleted manually to avoid duplicates and to let the new Route acquire the host.