### PR TITLE
Fix PDND schema editor image source and update deployments

### DIFF
--- a/.github/workflows/update-schema-editor-images.yaml
+++ b/.github/workflows/update-schema-editor-images.yaml
@@ -8,7 +8,8 @@ name: Update Schema Editor images
 on:
   schedule:
     - cron: "0 */6 * * *" # every 6 hours
-  workflow_dispatch: # manually trigger the workflow
+  workflow_dispatch:
+    # manually trigger the workflow
 
 permissions:
   contents: write
@@ -32,7 +33,7 @@ jobs:
             branch_name: update/schema-editor-api-image
             target_file: dati-semantic-schema-editor-api/deployment.yaml
           - title: Update Schema Editor API PDND docker image
-            image: ghcr.io/teamdigitale/dati-semantic-schema-editor-api
+            image: ghcr.io/teamdigitale/dati-semantic-schema-editor-api-pdnd
             branch_name: update/schema-editor-api-pdnd-image
             target_file: dati-semantic-schema-editor-api-pdnd/deployment.yaml
           - title: Update Vocabularies API docker image

--- a/dati-semantic-schema-editor-api-pdnd/deployment.yaml
+++ b/dati-semantic-schema-editor-api-pdnd/deployment.yaml
@@ -34,7 +34,7 @@ spec:
           emptyDir:
             sizeLimit: 100Mi
       containers:
-        - image: ghcr.io/teamdigitale/dati-semantic-schema-editor-api:0.2.0
+        - image: ghcr.io/teamdigitale/dati-semantic-schema-editor-api-pdnd:20260421-240-57d26e8
           imagePullPolicy: Always
           name: dati-semantic-schema-editor-api-pdnd
           # Load configuration variables from the ConfigMap.

--- a/dati-semantic-schema-editor-api/deployment.yaml
+++ b/dati-semantic-schema-editor-api/deployment.yaml
@@ -34,7 +34,7 @@ spec:
           emptyDir:
             sizeLimit: 100Mi
       containers:
-        - image: ghcr.io/teamdigitale/dati-semantic-schema-editor-api:0.2.0
+        - image: ghcr.io/teamdigitale/dati-semantic-schema-editor-api:20260421-241-a89bac7
           imagePullPolicy: Always
           name: dati-semantic-schema-editor-api
           # Load configuration variables from the ConfigMap.


### PR DESCRIPTION
## Summary
- fix the automated update workflow to use the dedicated `dati-semantic-schema-editor-api-pdnd` image for the PDND deployment
- update `dati-semantic-schema-editor-api-pdnd` deployment to the latest PDND image tag
- update `dati-semantic-schema-editor-api` deployment to the latest standard API image tag

## Test plan
- [x] Verify `dati-semantic-schema-editor-api-pdnd/deployment.yaml` now references `ghcr.io/teamdigitale/dati-semantic-schema-editor-api-pdnd`
- [x] Verify workflow matrix entry for "Schema Editor API PDND" points to the PDND image repository
- [x] Verify `dati-semantic-schema-editor-api/deployment.yaml` points to the intended updated API image tag

Made with [Cursor](https://cursor.com)