### PR TITLE
chore(pdnd): touch configmap to trigger pipeline replace

### DIFF
--- a/dati-semantic-schema-editor-api-pdnd/configmap.yaml
+++ b/dati-semantic-schema-editor-api-pdnd/configmap.yaml
@@ -1,5 +1,5 @@
 #
-# The Schema Editor API configuration containing
+# The Schema Editor API (PDND) configuration containing
 #   the references to the triplestore,
 #   the port to listen on, etc.
 #


### PR DESCRIPTION
## Why

The Tekton `task-update-resource` in the ISTAT pipeline only re-applies YAML files touched in the **last commit** (`git log -1 --stat | grep yaml`). As a result, `dati-semantic-schema-editor-api-pdnd/configmap.yaml` on the cluster is still at the state of PR #291 and is missing `GLOBAL_PREFIX` and `SERVER_URL` (added in PR #292 but never replayed to the cluster).

The pdnd pod, started by #313 with the dedicated image, now crash-loops with:

```
property SERVER_URL has failed the following constraints: isString
```

## What

Trivial comment-only touch on the pdnd configmap so that the next pipeline run picks it up and runs `oc replace` on it.