### PR TITLE
fix(updateConfig): persist credentials so git push is authenticated

### DIFF
--- a/.github/workflows/update-config.yaml
+++ b/.github/workflows/update-config.yaml
@@ -17,9 +17,9 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          persist-credentials: false
+          persist-credentials: true
 
       - name: yq - portable yaml processor
         uses: mikefarah/yq@5a7e72a743649b1b3a47d1a1d8214f3453173c51 # v4.52.4


### PR DESCRIPTION
## Problema

Il workflow `updateConfig` fallisce da circa il 10 aprile: lo step `Commit new config` esce con codice 128 sul `git push`:

```
fatal: could not read Username for 'https://github.com': No such device or address
```

Il commit locale avviene, ma il push non è autenticato.

## Causa

Lo step di checkout gira ora come **v6** (lo SHA pinnato `de0fac2e` è `actions/checkout` v6.0.2). In v5+ il default di `persist-credentials` è `false`: il `GITHUB_TOKEN` non viene più scritto nel git config, quindi il `git push` successivo resta senza credenziali. Prima del 10 aprile il vecchio `@v2` (Node12, poi deprecato/sostituito) persisteva le credenziali di default e il push funzionava.

## Fix

- `persist-credentials: true` → il token viene scritto nel git config e il `git push` torna autenticato (il job ha già `permissions: contents: write`).
- Allineato il commento del pin di checkout da `# v6` a `# v6.0.2` per combaciare con lo SHA, risolvendo il finding zizmor `ref-version-mismatch` che faceva fallire il super-linter.

## Note

Il workflow gira solo su `workflow_dispatch`, quindi va validato lanciandolo manualmente su `dev` dopo il merge (`serviceName` + `imageWithNewTag`) e verificando che lo step `Commit new config` faccia push senza errori.