### PR TITLE
Update Schema Editor API PDND docker image reference

### DIFF
--- a/.github/workflows/update-schema-editor-images.yaml
+++ b/.github/workflows/update-schema-editor-images.yaml
@@ -32,7 +32,7 @@ jobs:
             branch_name: update/schema-editor-api-image
             target_file: dati-semantic-schema-editor-api/deployment.yaml
           - title: Update Schema Editor API PDND docker image
-            image: ghcr.io/teamdigitale/dati-semantic-schema-editor-api
+            image: ghcr.io/teamdigitale/dati-semantic-schema-editor-api-pdnd
             branch_name: update/schema-editor-api-pdnd-image
             target_file: dati-semantic-schema-editor-api-pdnd/deployment.yaml
           - title: Update Vocabularies API docker image


### PR DESCRIPTION
Updated docker image name with the suffix "-pdnd" for dati-semantic-schema-editor-api-pdnd