### PR TITLE
feat(keycloak): deploy Keycloak 26 in ndc-dev for admin panel auth

### DIFF
--- a/keycloak/configmap.yaml
+++ b/keycloak/configmap.yaml
@@ -1,0 +1,121 @@
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: keycloak-realm-seed
+  namespace: ndc-dev
+  labels:
+    app: keycloak
+data:
+  realm-ndc.json: |
+    {
+      "realm": "ndc",
+      "enabled": true,
+      "displayName": "NDC",
+      "displayNameHtml": "Catalogo Nazionale Dati",
+      "registrationAllowed": false,
+      "registrationEmailAsUsername": false,
+      "rememberMe": false,
+      "verifyEmail": false,
+      "loginWithEmailAllowed": true,
+      "duplicateEmailsAllowed": false,
+      "resetPasswordAllowed": false,
+      "editUsernameAllowed": false,
+      "bruteForceProtected": true,
+      "permanentLockout": false,
+      "loginTheme": "keycloak",
+      "accessTokenLifespan": 1800,
+      "ssoSessionIdleTimeout": 1800,
+      "ssoSessionMaxLifespan": 36000,
+      "offlineSessionIdleTimeout": 2592000,
+      "internationalizationEnabled": false,
+      "sslRequired": "external",
+      "roles": {
+        "realm": [
+          {
+            "name": "ndc-admin",
+            "description": "NDC admin: accesso completo al pannello"
+          },
+          {
+            "name": "ndc-viewer",
+            "description": "NDC viewer: accesso in sola lettura"
+          },
+          {
+            "name": "ndc-service",
+            "description": "NDC service account: chiamate machine-to-machine"
+          }
+        ]
+      },
+      "users": [
+        {
+          "username": "admin-test",
+          "enabled": true,
+          "emailVerified": true,
+          "email": "admin-test@example.com",
+          "firstName": "Admin",
+          "lastName": "Test",
+          "credentials": [
+            {
+              "type": "password",
+              "value": "changeme",
+              "temporary": true
+            }
+          ],
+          "realmRoles": ["ndc-admin"]
+        },
+        {
+          "username": "viewer-test",
+          "enabled": true,
+          "emailVerified": true,
+          "email": "viewer-test@example.com",
+          "firstName": "Viewer",
+          "lastName": "Test",
+          "credentials": [
+            {
+              "type": "password",
+              "value": "changeme",
+              "temporary": true
+            }
+          ],
+          "realmRoles": ["ndc-viewer"]
+        }
+      ],
+      "clients": [
+        {
+          "clientId": "ndc-admin-bff-client",
+          "name": "NDC Admin Panel (BFF)",
+          "description": "Confidential client per il pannello admin (Authorization Code + PKCE).",
+          "enabled": true,
+          "protocol": "openid-connect",
+          "publicClient": false,
+          "clientAuthenticatorType": "client-secret",
+          "secret": "${BFF_CLIENT_SECRET}",
+          "standardFlowEnabled": true,
+          "implicitFlowEnabled": false,
+          "directAccessGrantsEnabled": false,
+          "serviceAccountsEnabled": false,
+          "frontchannelLogout": true,
+          "alwaysDisplayInConsole": false,
+          "redirectUris": [
+            "https://admin-ndc-dev.apps.cloudpub.testedev.istat.it/login/oauth2/code/keycloak"
+          ],
+          "webOrigins": [
+            "https://admin-ndc-dev.apps.cloudpub.testedev.istat.it"
+          ],
+          "attributes": {
+            "pkce.code.challenge.method": "S256",
+            "post.logout.redirect.uris": "https://admin-ndc-dev.apps.cloudpub.testedev.istat.it/*"
+          },
+          "defaultClientScopes": [
+            "profile",
+            "email",
+            "roles",
+            "web-origins"
+          ],
+          "optionalClientScopes": [
+            "address",
+            "phone"
+          ]
+        }
+      ]
+    }

--- a/keycloak/deployment.yaml
+++ b/keycloak/deployment.yaml
@@ -1,0 +1,113 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: keycloak
+  name: keycloak
+  namespace: ndc-dev
+spec:
+  replicas: 1
+  revisionHistoryLimit: 5
+  selector:
+    matchLabels:
+      app: keycloak
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: keycloak
+      name: keycloak
+    spec:
+      containers:
+        - name: keycloak
+          image: quay.io/keycloak/keycloak:26.1
+          imagePullPolicy: IfNotPresent
+          args:
+            - start
+            - --import-realm
+          env:
+            - name: KC_DB
+              value: dev-file
+            - name: KC_HOSTNAME
+              value: https://keycloak-ndc-dev.apps.cloudpub.testedev.istat.it
+            - name: KC_HOSTNAME_STRICT_HTTPS
+              value: "false"
+            - name: KC_HTTP_ENABLED
+              value: "true"
+            - name: KC_PROXY_HEADERS
+              value: xforwarded
+            - name: KC_HEALTH_ENABLED
+              value: "true"
+            - name: KC_LOG_LEVEL
+              value: INFO
+            - name: KEYCLOAK_ADMIN
+              valueFrom:
+                secretKeyRef:
+                  name: keycloak-admin-dev
+                  key: KEYCLOAK_ADMIN
+            - name: KEYCLOAK_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: keycloak-admin-dev
+                  key: KEYCLOAK_ADMIN_PASSWORD
+            # Iniettato nel realm seed via ${BFF_CLIENT_SECRET} (sostituzione
+            # automatica all'import). Stesso valore usato dal pannello admin
+            # (deployment dati-semantic-admin -> admin-oauth-dev/client-secret):
+            # single source of truth del client secret confidential.
+            - name: BFF_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: admin-oauth-dev
+                  key: client-secret
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+            - name: management
+              containerPort: 9000
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /health/live
+              port: 9000
+              scheme: HTTP
+            initialDelaySeconds: 120
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health/ready
+              port: 9000
+              scheme: HTTP
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+            requests:
+              cpu: 250m
+              memory: 384Mi
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - name: realm-import
+              mountPath: /opt/keycloak/data/import
+              readOnly: true
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - name: realm-import
+          configMap:
+            name: keycloak-realm-seed

--- a/keycloak/route.yaml
+++ b/keycloak/route.yaml
@@ -1,0 +1,20 @@
+---
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: keycloak
+  namespace: ndc-dev
+  labels:
+    app: keycloak
+spec:
+  host: keycloak-ndc-dev.apps.cloudpub.testedev.istat.it
+  to:
+    kind: Service
+    name: keycloak
+    weight: 100
+  port:
+    targetPort: 8080
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+  wildcardPolicy: None

--- a/keycloak/service.yaml
+++ b/keycloak/service.yaml
@@ -1,0 +1,17 @@
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: keycloak
+  namespace: ndc-dev
+  labels:
+    app: keycloak
+spec:
+  ports:
+    - name: http
+      protocol: TCP
+      port: 8080
+      targetPort: 8080
+  selector:
+    app: keycloak
+  sessionAffinity: None


### PR DESCRIPTION
## Cosa

Aggiunta cartella \`keycloak/\` con i manifest per deployare Keycloak 26 in \`ndc-dev\`, identity provider del nuovo pannello admin (\`dati-semantic-admin\`, repo: https://github.com/teamdigitale/dati-semantic-admin).

## File aggiunti

- \`keycloak/deployment.yaml\` — Deployment singolo replica, immagine \`quay.io/keycloak/keycloak:26.1\`, args \`start --import-realm\`, env \`KC_*\` per modalita' production OCP-friendly (edge TLS + proxy-headers xforwarded), bootstrap admin via Secret out-of-band \`keycloak-admin-dev\`, ConfigMap montata su \`/opt/keycloak/data/import\`, health/ready su porta 9000
- \`keycloak/service.yaml\` — ClusterIP 8080
- \`keycloak/route.yaml\` — host \`keycloak-ndc-dev.apps.cloudpub.testedev.istat.it\`, edge termination
- \`keycloak/configmap.yaml\` — realm seed JSON: realm \`ndc\`, client confidential \`ndc-admin-bff-client\` (Auth Code + PKCE), ruoli \`ndc-admin\`/\`ndc-viewer\`/\`ndc-service\`, 2 utenti test

## Perche' la cartella si chiama \`keycloak/\` e non \`dati-semantic-keycloak/\`

Per saltare deliberatamente la \`task-skopeo-copy-v1\` della \`pipeline-deploy-dev\` (filtro \`grep \"dati-\"\` sulla lista cartelle). Il task \`task-update-resource\` applica comunque i manifest. Il Deployment pulla quindi direttamente da \`quay.io\`, evitando di dover mirrorare l'immagine Keycloak su \`ghcr.io/teamdigitale/\`. Stesso pattern gia' adottato per \`external-services/\`.

## Note operative pre-deploy

Prima del rollout su \`ndc-dev\` va creato il Secret \`keycloak-admin-dev\` out-of-band (non in git):

\`\`\`
oc -n ndc-dev create secret generic keycloak-admin-dev \\
  --from-literal=KEYCLOAK_ADMIN=admin \\
  --from-literal=KEYCLOAK_ADMIN_PASSWORD=<random>
\`\`\`

## Stato DB e persistenza

H2 in modalita' \`dev-file\` su filesystem ephemeral del container: il realm viene re-importato ad ogni pod restart, e gli utenti aggiunti via UI Keycloak si perdono. Accettato per ambiente di sviluppo (vedi \`backlog/MGT-DASH/deploy_plan.md\` punto 3.3). Per TEST e PROD si valutera' DB persistente.

## Smoke test post-deploy

1. \`GET https://keycloak-ndc-dev.apps.cloudpub.testedev.istat.it/realms/ndc/.well-known/openid-configuration\` -> 200 con discovery document
2. Login alla console admin (\`/admin\`) con le credenziali del Secret
3. Login al realm \`ndc\` con \`admin-test/changeme\` -> access token con claim \`realm_access.roles\` popolato

## Tracking

Fase 1 del piano di consegna pannello admin documentato in \`backlog/MGT-DASH/deploy_plan.md\` (non in questo repo).