### PR TITLE
feat(admin): deploy pannello dati-semantic-admin in ndc-dev

### DIFF
--- a/dati-semantic-admin/autoscaling.yaml
+++ b/dati-semantic-admin/autoscaling.yaml
@@ -1,0 +1,19 @@
+kind: HorizontalPodAutoscaler
+apiVersion: autoscaling/v2beta2
+metadata:
+  name: autoscaling-dati-semantic-admin
+  namespace: ndc-dev
+spec:
+  scaleTargetRef:
+    kind: Deployment
+    name: dati-semantic-admin
+    apiVersion: apps.openshift.io/v1
+  minReplicas: 1
+  maxReplicas: 2
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80

--- a/dati-semantic-admin/configmap.yaml
+++ b/dati-semantic-admin/configmap.yaml
@@ -1,0 +1,5 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: configmap-admin
+  namespace: ndc-dev

--- a/dati-semantic-admin/deployment.yaml
+++ b/dati-semantic-admin/deployment.yaml
@@ -1,0 +1,89 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: dati-semantic-admin
+  name: dati-semantic-admin
+  namespace: ndc-dev
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: dati-semantic-admin
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: dati-semantic-admin
+      name: dati-semantic-admin
+    spec:
+      containers:
+        - name: dati-semantic-admin
+          # Tag pinnato a mano in attesa del secret cross-repo che abilita
+          # l'update automatico del tag via update-config.yaml.
+          image: ghcr.io/teamdigitale/dati-semantic-admin:1a70cf8caeba1fa34c93f855d1e7afef62cfc69f
+          imagePullPolicy: Always
+          env:
+            # Spring e' dietro route OpenShift edge (TLS sul router, HTTP nel pod):
+            # senza questo il redirect_uri OAuth2 verrebbe costruito in http:// e
+            # Keycloak lo rifiuterebbe (registrato come https).
+            - name: SERVER_FORWARD_HEADERS_STRATEGY
+              value: framework
+            - name: SERVER_SERVLET_SESSION_COOKIE_SECURE
+              value: "true"
+            # issuer-uri = URL PUBBLICO: il claim 'iss' del token emesso da
+            # Keycloak (KC_HOSTNAME pubblico) deve combaciare per la validazione.
+            - name: SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_ISSUER_URI
+              value: https://keycloak-ndc-dev.apps.cloudpub.testedev.istat.it/realms/ndc
+            - name: SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_KEYCLOAK_CLIENT_ID
+              value: ndc-admin-bff-client
+            - name: SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_KEYCLOAK_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: admin-oauth-dev
+                  key: client-secret
+            # Backend NDC: chiamata service-to-service interna al namespace.
+            - name: NDC_BACKEND_URL
+              value: http://dati-semantic-backend:8080
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          resources:
+            limits:
+              cpu: 500m
+              memory: 768Mi
+            requests:
+              cpu: 100m
+              memory: 256Mi
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30

--- a/dati-semantic-admin/imagestream.yaml
+++ b/dati-semantic-admin/imagestream.yaml
@@ -1,0 +1,10 @@
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  name: dati-semantic-admin
+  namespace: ndc-dev
+  labels:
+    application: dati-semantic-admin
+spec:
+  lookupPolicy:
+    local: false

--- a/dati-semantic-admin/route.yaml
+++ b/dati-semantic-admin/route.yaml
@@ -1,0 +1,20 @@
+---
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: dati-semantic-admin
+  namespace: ndc-dev
+  labels:
+    application: dati-semantic-admin
+spec:
+  host: admin-ndc-dev.apps.cloudpub.testedev.istat.it
+  to:
+    kind: Service
+    name: dati-semantic-admin
+    weight: 100
+  port:
+    targetPort: 8080
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+  wildcardPolicy: None

--- a/dati-semantic-admin/service.yaml
+++ b/dati-semantic-admin/service.yaml
@@ -1,0 +1,16 @@
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: dati-semantic-admin
+  namespace: ndc-dev
+  labels:
+    app: dati-semantic-admin
+spec:
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080
+  selector:
+    app: dati-semantic-admin
+  sessionAffinity: None


### PR DESCRIPTION
## Cosa

Aggiunge la cartella \`dati-semantic-admin/\` con i 6 manifest standard per deployare il pannello admin (BFF Spring Boot + SPA React, single deployment) in \`ndc-dev\`. Componente del piano admin (repo: https://github.com/teamdigitale/dati-semantic-admin).

## File

- \`deployment.yaml\` — singolo replica, immagine pinnata a mano (vedi sotto), env OAuth2 + backend
- \`service.yaml\` — ClusterIP 8080
- \`route.yaml\` — host \`admin-ndc-dev.apps.cloudpub.testedev.istat.it\`, edge TLS
- \`imagestream.yaml\` / \`configmap.yaml\` / \`autoscaling.yaml\` — convenzione standard

## Immagine pinnata a mano (temporaneo)

\`image: ghcr.io/teamdigitale/dati-semantic-admin:1a70cf8...\` impostata manualmente in attesa del secret cross-repo che abiliterà l'update automatico via \`update-config.yaml\` (job \`deploy\` nel workflow CI del repo admin). Da quel momento il tag verrà aggiornato dalla pipeline come per le altre componenti.

## Dettagli che evitano rotture subdole del login

- \`SERVER_FORWARD_HEADERS_STRATEGY=framework\`: dietro route edge TLS Spring vedrebbe HTTP e costruirebbe il \`redirect_uri\` OAuth2 in \`http://\` → mismatch con quello \`https\` registrato in Keycloak. Con questo onora gli header X-Forwarded-*
- \`issuer-uri\` = URL **pubblico** di Keycloak: il claim \`iss\` del token (emesso con \`KC_HOSTNAME\` pubblico) deve combaciare per la validazione
- \`SERVER_SERVLET_SESSION_COOKIE_SECURE=true\`

## Dipendenze per il pod Ready

Il pod **non** diventerà Ready finché non ci sono entrambi:
1. Secret \`admin-oauth-dev\` (key \`client-secret\`) — già richiesto a ops ISTAT, condiviso con Keycloak
2. Keycloak su e raggiungibile — Spring fa la OIDC discovery contro l'issuer all'avvio

Atteso: prima del secret il pod resta in \`CreateContainerConfigError\` (come keycloak). Mergiamo ora per validare la meccanica della pipeline sul ramo \`dati-*\` (incluso \`task-skopeo-copy-v1\` che copia l'immagine ghcr → registry interno).