### PR TITLE
fix(keycloak): use KC_BOOTSTRAP_ADMIN_* env (KEYCLOAK_ADMIN deprecati)

### DIFF
--- a/keycloak/deployment.yaml
+++ b/keycloak/deployment.yaml
@@ -45,12 +45,14 @@ spec:
               value: "true"
             - name: KC_LOG_LEVEL
               value: INFO
-            - name: KEYCLOAK_ADMIN
+            # Nomi env nuovi (KC_BOOTSTRAP_ADMIN_*): KEYCLOAK_ADMIN/_PASSWORD sono
+            # deprecati da Keycloak 26. Le chiavi del Secret restano invariate.
+            - name: KC_BOOTSTRAP_ADMIN_USERNAME
               valueFrom:
                 secretKeyRef:
                   name: keycloak-admin-dev
                   key: KEYCLOAK_ADMIN
-            - name: KEYCLOAK_ADMIN_PASSWORD
+            - name: KC_BOOTSTRAP_ADMIN_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: keycloak-admin-dev


### PR DESCRIPTION
## Cosa

Keycloak 26 deprecava le env `KEYCLOAK_ADMIN` / `KEYCLOAK_ADMIN_PASSWORD` (bootstrap admin console) a favore di `KC_BOOTSTRAP_ADMIN_USERNAME` / `KC_BOOTSTRAP_ADMIN_PASSWORD`. Allineamento per evitare un warning all'avvio e la rimozione in una major futura.

## Nota

Cambia **solo il nome della env** nel deployment. Le chiavi del Secret `keycloak-admin-dev` restano `KEYCLOAK_ADMIN` / `KEYCLOAK_ADMIN_PASSWORD`: nessun impatto sui Secret da creare.

Warning osservato durante un test del realm import su Keycloak 26.1:
```
KC-SERVICES0110: Environment variable 'KEYCLOAK_ADMIN' is deprecated, use 'KC_BOOTSTRAP_ADMIN_USERNAME' instead
```