### PR TITLE
feat(dev): enable OAuth2 on backend + ndc-backend audience in Keycloak realm

### DIFF
--- a/dati-semantic-backend/deployment.yaml
+++ b/dati-semantic-backend/deployment.yaml
@@ -77,6 +77,8 @@ spec:
                   name: mysql-dev
             - name: LOGGING_LEVEL_IT_GOV_INNOVAZIONE_NDC
               value: debug
+            - name: OAUTH2_ISSUER_URI
+              value: https://keycloak-ndc-dev.apps.cloudpub.testedev.istat.it/realms/ndc
             - name: ALERTER_SMTP_SERVER
               value: smtp.istat.it
             - name: ALERTER_SMTP_PORT

--- a/keycloak/configmap.yaml
+++ b/keycloak/configmap.yaml
@@ -106,6 +106,20 @@ data:
             "pkce.code.challenge.method": "S256",
             "post.logout.redirect.uris": "https://admin-ndc-dev.apps.cloudpub.testedev.istat.it/*"
           },
+          "protocolMappers": [
+            {
+              "name": "ndc-backend-audience",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-audience-mapper",
+              "consentRequired": false,
+              "config": {
+                "included.custom.audience": "ndc-backend",
+                "id.token.claim": "false",
+                "access.token.claim": "true",
+                "introspection.token.claim": "true"
+              }
+            }
+          ],
           "defaultClientScopes": [
             "profile",
             "email",

--- a/keycloak/deployment.yaml
+++ b/keycloak/deployment.yaml
@@ -22,6 +22,11 @@ spec:
       labels:
         app: keycloak
       name: keycloak
+      annotations:
+        # Bump per forzare il rollout del pod e quindi il re-import del realm
+        # (DB H2 su emptyDir: a ogni restart il realm viene ricaricato dal
+        # ConfigMap keycloak-realm-seed). Incrementare a ogni modifica del realm.
+        ndc.istat.it/realm-seed-revision: "2-ndc-backend-audience"
     spec:
       containers:
         - name: keycloak


### PR DESCRIPTION
## Why
The admin panel (BFF) proxies user requests to the harvester backend with a Keycloak access token. In `ndc-dev` the backend currently runs Basic-auth only and the realm tokens lack the `ndc-backend` audience, so every protected call returns 401 — which the SPA interprets as session expiry and loops on the login redirect.

## Changes (`ndc-dev`)
- **dati-semantic-backend/deployment.yaml**: `OAUTH2_ISSUER_URI` pointing at the dev Keycloak realm `ndc`. Enables the backend's OAuth2 resource-server validation (Basic auth stays on; the two flags coexist). Requires the backend image built from teamdigitale/dati-semantic-backend#190.
- **keycloak/configmap.yaml**: audience protocol mapper on `ndc-admin-bff-client` so access tokens carry `aud: ndc-backend` (validated by the backend).
- **keycloak/deployment.yaml**: pod-template annotation bump to force a rollout, so the realm is re-imported from the updated ConfigMap (dev uses H2 on emptyDir).

## Notes
- Please **squash-merge**: the deploy pipeline only applies manifests touched by the last commit, and skips merge commits that modify existing files.
- The Keycloak pod restart re-imports the realm and resets runtime sessions in dev (seed users reload from JSON). Acceptable for dev.