### PR TITLE
fix(dev): disable mail health indicator on backend

### DIFF
--- a/dati-semantic-backend/deployment.yaml
+++ b/dati-semantic-backend/deployment.yaml
@@ -96,6 +96,8 @@ spec:
               value: "true"
             - name: JAVA_MAIL_DEBUG
               value: "true"
+            - name: MANAGEMENT_HEALTH_MAIL_ENABLED
+              value: "false"
           image: ghcr.io/teamdigitale/dati-semantic-backend:20260624-548-dea84a6
           imagePullPolicy: Always
           livenessProbe:


### PR DESCRIPTION
## Problema

`GET /status` resta appeso ~2 min e poi va in **504**.

`ApplicationStatusController` aggrega l'health completo di Spring Boot. Con `spring-boot-starter-mail` configurato (`smtp.istat.it:465`), l'health indicator `mail` apre una connessione SMTP con `timeout -1` (infinito). L'host non è raggiungibile dai pod `ndc-dev`, quindi la chiamata blocca sul connect TCP finché il router OpenShift taglia con 504.

I probe liveness/readiness usano i *group* `/actuator/health/{liveness,readiness}` (senza `mail`), per questo il pod resta `1/1 Running`: solo `/status` (aggregato completo) si appende.

## Fix

`MANAGEMENT_HEALTH_MAIL_ENABLED=false` sul deployment del backend: rimuove l'indicator `mail` dall'aggregato. L'alerter mail (sender in background, non critico) continua a funzionare; solo l'health probe non gating più `/status`.

⚠️ Merge **squash** (modifica di un manifest esistente: i merge commit verrebbero saltati da `task-update-resource`).