### PR TITLE
fix(dev): emit realm_access.roles in ID token for admin panel

### DIFF
--- a/keycloak/configmap.yaml
+++ b/keycloak/configmap.yaml
@@ -118,6 +118,22 @@ data:
                 "access.token.claim": "true",
                 "introspection.token.claim": "true"
               }
+            },
+            {
+              "name": "ndc-realm-roles",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-usermodel-realm-role-mapper",
+              "consentRequired": false,
+              "config": {
+                "claim.name": "realm_access.roles",
+                "jsonType.label": "String",
+                "multivalued": "true",
+                "usermodel.realmRoleMapping.rolePrefix": "",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "userinfo.token.claim": "true",
+                "introspection.token.claim": "true"
+              }
             }
           ],
           "defaultClientScopes": [

--- a/keycloak/deployment.yaml
+++ b/keycloak/deployment.yaml
@@ -26,7 +26,7 @@ spec:
         # Bump per forzare il rollout del pod e quindi il re-import del realm
         # (DB H2 su emptyDir: a ogni restart il realm viene ricaricato dal
         # ConfigMap keycloak-realm-seed). Incrementare a ogni modifica del realm.
-        ndc.istat.it/realm-seed-revision: "2-ndc-backend-audience"
+        ndc.istat.it/realm-seed-revision: "3-realm-roles-mapper"
     spec:
       containers:
         - name: keycloak


### PR DESCRIPTION
## Problema

Login al pannello OK ma `/bff/api/me` ritorna `roles: []` anche per `admin-test` (che ha `ndc-admin` assegnato nel realm).

`KeycloakOidcUserService` legge i ruoli da `oidcUser.getClaims()` (claim dell'**ID token** + userinfo). Il mapper "realm roles" di default dello scope `roles` scrive `realm_access.roles` **solo nell'access token** (`id.token.claim=false`), quindi nell'ID token il claim non c'è → ruoli vuoti.

## Fix

- Aggiunto al client `ndc-admin-bff-client` un protocol mapper `oidc-usermodel-realm-role-mapper` (`ndc-realm-roles`) che emette `realm_access.roles` in **ID token + userinfo** (oltre all'access token), senza prefisso.
- Bump `realm-seed-revision` → `3-realm-roles-mapper` per forzare il rollout del pod Keycloak e il re-import del realm (H2 su emptyDir).

Il role assignment dell'utente (`admin-test` → `ndc-admin`) era già corretto.

⚠️ Merge **squash** (modifica manifest esistenti).