### PR TITLE
fix: bump dati-semantic-backend to 20250922-520-387766a

### DIFF
--- a/dati-semantic-backend/deployment.yaml
+++ b/dati-semantic-backend/deployment.yaml
@@ -95,7 +95,7 @@ spec:
               value: 'true'
             - name: JAVA_MAIL_DEBUG
               value: 'false'
-          image: ghcr.io/teamdigitale/dati-semantic-backend:20250624-500-1135528
+          image: ghcr.io/teamdigitale/dati-semantic-backend:20250922-520-387766a
           imagePullPolicy: Always
           livenessProbe:
             failureThreshold: 3


### PR DESCRIPTION
## Summary

- Aggiorna l'immagine di `dati-semantic-backend` da `20250624-500-1135528` a `20250922-520-387766a`
- La versione in prod crasha su `GET /dashboard/aggregated-count-data` con `NullPointerException: Name is null` perché `SemanticContentStatsService.getRawStats()` non gestiva righe con `RESOURCE_TYPE = NULL` nel DB
- Il fix è nel commit `387766a` ("fixes stats #175"): aggiunto try/catch nel row mapper
- Zero migrazioni DB tra le due versioni (il set Flyway rimane V2–V10)

## Test plan

- [ ] Verificare che `GET /api/dashboard/aggregated-count-data` risponda 200 dopo il deploy