### PR TITLE
fix: bump dati-semantic-backend to 20250922-520-387766a

### DIFF
--- a/dati-semantic-backend/deployment.yaml
+++ b/dati-semantic-backend/deployment.yaml
@@ -99,7 +99,7 @@ spec:
               value: "true"
             - name: JAVA_MAIL_DEBUG
               value: "true"
-          image: ghcr.io/teamdigitale/dati-semantic-backend:20250624-500-1135528
+          image: ghcr.io/teamdigitale/dati-semantic-backend:20250922-520-387766a
           imagePullPolicy: Always
           livenessProbe:
             failureThreshold: 3


### PR DESCRIPTION
## Summary

- Aggiorna l'immagine di `dati-semantic-backend` da `20250624-500-1135528` a `20250922-520-387766a`
- Fix per `NullPointerException: Name is null` su `GET /dashboard/aggregated-count-data`: righe con `RESOURCE_TYPE = NULL` nel DB causano crash nel row mapper di `SemanticContentStatsService.getRawStats()`
- Il fix è nel commit `387766a` ("fixes stats #175"): aggiunto try/catch nel row mapper
- Zero migrazioni DB tra le due versioni (set Flyway invariato V2–V10)

## Test plan

- [ ] Verificare che `GET /api/dashboard/aggregated-count-data` risponda 200 su ndc-test dopo il deploy