### PR TITLE
bump images + add admin/keycloak for ndc-test

### DIFF
--- a/dati-semantic-admin/autoscaling.yaml
+++ b/dati-semantic-admin/autoscaling.yaml
@@ -1,0 +1,19 @@
+kind: HorizontalPodAutoscaler
+apiVersion: autoscaling/v2beta2
+metadata:
+  name: autoscaling-dati-semantic-admin
+  namespace: ndc-test
+spec:
+  scaleTargetRef:
+    kind: Deployment
+    name: dati-semantic-admin
+    apiVersion: apps.openshift.io/v1
+  minReplicas: 1
+  maxReplicas: 2
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80

--- a/dati-semantic-admin/configmap.yaml
+++ b/dati-semantic-admin/configmap.yaml
@@ -1,0 +1,5 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: configmap-admin
+  namespace: ndc-test

--- a/dati-semantic-admin/deployment.yaml
+++ b/dati-semantic-admin/deployment.yaml
@@ -1,0 +1,83 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: dati-semantic-admin
+  name: dati-semantic-admin
+  namespace: ndc-test
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: dati-semantic-admin
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: dati-semantic-admin
+      name: dati-semantic-admin
+      annotations:
+        wordpress-bootstrap-trigger: bootstrap-20260624-17-fee1b65
+    spec:
+      containers:
+        - name: dati-semantic-admin
+          image: ghcr.io/teamdigitale/dati-semantic-admin:20260624-17-fee1b65
+          imagePullPolicy: Always
+          env:
+            - name: SERVER_FORWARD_HEADERS_STRATEGY
+              value: framework
+            - name: SERVER_SERVLET_SESSION_COOKIE_SECURE
+              value: "true"
+            - name: SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_ISSUER_URI
+              value: https://keycloak-ndc-test.apps.cloudpub.testedev.istat.it/realms/ndc
+            - name: SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_KEYCLOAK_CLIENT_ID
+              value: ndc-admin-bff-client
+            - name: SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_KEYCLOAK_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: admin-oauth-test
+                  key: client-secret
+            - name: NDC_BACKEND_URL
+              value: http://dati-semantic-backend:8080
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          resources:
+            limits:
+              cpu: 500m
+              memory: 768Mi
+            requests:
+              cpu: 100m
+              memory: 256Mi
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30

--- a/dati-semantic-admin/imagestream.yaml
+++ b/dati-semantic-admin/imagestream.yaml
@@ -1,0 +1,10 @@
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  name: dati-semantic-admin
+  namespace: ndc-test
+  labels:
+    application: dati-semantic-admin
+spec:
+  lookupPolicy:
+    local: false

--- a/dati-semantic-admin/route.yaml
+++ b/dati-semantic-admin/route.yaml
@@ -1,0 +1,20 @@
+---
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: dati-semantic-admin
+  namespace: ndc-test
+  labels:
+    application: dati-semantic-admin
+spec:
+  host: admin-ndc-test.apps.cloudpub.testedev.istat.it
+  to:
+    kind: Service
+    name: dati-semantic-admin
+    weight: 100
+  port:
+    targetPort: 8080
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+  wildcardPolicy: None

--- a/dati-semantic-admin/service.yaml
+++ b/dati-semantic-admin/service.yaml
@@ -1,0 +1,16 @@
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: dati-semantic-admin
+  namespace: ndc-test
+  labels:
+    app: dati-semantic-admin
+spec:
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080
+  selector:
+    app: dati-semantic-admin
+  sessionAffinity: None

--- a/dati-semantic-backend/deployment.yaml
+++ b/dati-semantic-backend/deployment.yaml
@@ -99,7 +99,7 @@ spec:
               value: "true"
             - name: JAVA_MAIL_DEBUG
               value: "true"
-          image: ghcr.io/teamdigitale/dati-semantic-backend:20250922-520-387766a
+          image: ghcr.io/teamdigitale/dati-semantic-backend:20260624-548-dea84a6
           imagePullPolicy: Always
           livenessProbe:
             failureThreshold: 3

--- a/dati-semantic-lode/deployment.yaml
+++ b/dati-semantic-lode/deployment.yaml
@@ -31,7 +31,7 @@ spec:
               value: "https://webvowl-ndc-test.apps.cloudpub.testedev.istat.it/#iri="
               # - name: MATOMO_SITE_ID  # FIXME
               #   value: "35"
-          image: ghcr.io/teamdigitale/dati-semantic-lode:20251212-32-7c632b6
+          image: ghcr.io/teamdigitale/dati-semantic-lode:20260414-42-d55c02c
           imagePullPolicy: Always
           name: dati-semantic-lode
           ports:

--- a/dati-semantic-lodview/deployment.yaml
+++ b/dati-semantic-lodview/deployment.yaml
@@ -44,7 +44,7 @@ spec:
               value: Questo strumento consente la navigazione web dei
                 contenuti delle ontologie e dei vocabolari 
                 controllati per la pubblica amministrazione.
-          image: ghcr.io/teamdigitale/dati-semantic-lodview:20250704-127-913191b
+          image: ghcr.io/teamdigitale/dati-semantic-lodview:20260414-134-5605877
           imagePullPolicy: Always
           livenessProbe:
             failureThreshold: 300

--- a/dati-semantic-webvowl/deployment.yaml
+++ b/dati-semantic-webvowl/deployment.yaml
@@ -24,7 +24,7 @@ spec:
       name: dati-semantic-webvowl
     spec:
       containers:
-        - image: ghcr.io/teamdigitale/dati-semantic-webvowl:20230210-18-2c46742
+        - image: ghcr.io/teamdigitale/dati-semantic-webvowl:20260217-22-3c91ef3
           imagePullPolicy: Always
           name: dati-semantic-webvowl
           ports:

--- a/keycloak/configmap.yaml
+++ b/keycloak/configmap.yaml
@@ -1,0 +1,151 @@
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: keycloak-realm-seed
+  namespace: ndc-test
+  labels:
+    app: keycloak
+data:
+  realm-ndc.json: |
+    {
+      "realm": "ndc",
+      "enabled": true,
+      "displayName": "NDC",
+      "displayNameHtml": "Catalogo Nazionale Dati",
+      "registrationAllowed": false,
+      "registrationEmailAsUsername": false,
+      "rememberMe": false,
+      "verifyEmail": false,
+      "loginWithEmailAllowed": true,
+      "duplicateEmailsAllowed": false,
+      "resetPasswordAllowed": false,
+      "editUsernameAllowed": false,
+      "bruteForceProtected": true,
+      "permanentLockout": false,
+      "loginTheme": "keycloak",
+      "accessTokenLifespan": 1800,
+      "ssoSessionIdleTimeout": 1800,
+      "ssoSessionMaxLifespan": 36000,
+      "offlineSessionIdleTimeout": 2592000,
+      "internationalizationEnabled": false,
+      "sslRequired": "external",
+      "roles": {
+        "realm": [
+          {
+            "name": "ndc-admin",
+            "description": "NDC admin: accesso completo al pannello"
+          },
+          {
+            "name": "ndc-viewer",
+            "description": "NDC viewer: accesso in sola lettura"
+          },
+          {
+            "name": "ndc-service",
+            "description": "NDC service account: chiamate machine-to-machine"
+          }
+        ]
+      },
+      "users": [
+        {
+          "username": "admin-test",
+          "enabled": true,
+          "emailVerified": true,
+          "email": "admin-test@example.com",
+          "firstName": "Admin",
+          "lastName": "Test",
+          "credentials": [
+            {
+              "type": "password",
+              "value": "changeme",
+              "temporary": true
+            }
+          ],
+          "realmRoles": ["ndc-admin"]
+        },
+        {
+          "username": "viewer-test",
+          "enabled": true,
+          "emailVerified": true,
+          "email": "viewer-test@example.com",
+          "firstName": "Viewer",
+          "lastName": "Test",
+          "credentials": [
+            {
+              "type": "password",
+              "value": "changeme",
+              "temporary": true
+            }
+          ],
+          "realmRoles": ["ndc-viewer"]
+        }
+      ],
+      "clients": [
+        {
+          "clientId": "ndc-admin-bff-client",
+          "name": "NDC Admin Panel (BFF)",
+          "description": "Confidential client per il pannello admin (Authorization Code + PKCE).",
+          "enabled": true,
+          "protocol": "openid-connect",
+          "publicClient": false,
+          "clientAuthenticatorType": "client-secret",
+          "secret": "${BFF_CLIENT_SECRET}",
+          "standardFlowEnabled": true,
+          "implicitFlowEnabled": false,
+          "directAccessGrantsEnabled": false,
+          "serviceAccountsEnabled": false,
+          "frontchannelLogout": true,
+          "alwaysDisplayInConsole": false,
+          "redirectUris": [
+            "https://admin-ndc-test.apps.cloudpub.testedev.istat.it/login/oauth2/code/keycloak"
+          ],
+          "webOrigins": [
+            "https://admin-ndc-test.apps.cloudpub.testedev.istat.it"
+          ],
+          "attributes": {
+            "pkce.code.challenge.method": "S256",
+            "post.logout.redirect.uris": "https://admin-ndc-test.apps.cloudpub.testedev.istat.it/*"
+          },
+          "protocolMappers": [
+            {
+              "name": "ndc-backend-audience",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-audience-mapper",
+              "consentRequired": false,
+              "config": {
+                "included.custom.audience": "ndc-backend",
+                "id.token.claim": "false",
+                "access.token.claim": "true",
+                "introspection.token.claim": "true"
+              }
+            },
+            {
+              "name": "ndc-realm-roles",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-usermodel-realm-role-mapper",
+              "consentRequired": false,
+              "config": {
+                "claim.name": "realm_access.roles",
+                "jsonType.label": "String",
+                "multivalued": "true",
+                "usermodel.realmRoleMapping.rolePrefix": "",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "userinfo.token.claim": "true",
+                "introspection.token.claim": "true"
+              }
+            }
+          ],
+          "defaultClientScopes": [
+            "profile",
+            "email",
+            "roles",
+            "web-origins"
+          ],
+          "optionalClientScopes": [
+            "address",
+            "phone"
+          ]
+        }
+      ]
+    }

--- a/keycloak/deployment.yaml
+++ b/keycloak/deployment.yaml
@@ -1,0 +1,111 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: keycloak
+  name: keycloak
+  namespace: ndc-test
+spec:
+  replicas: 1
+  revisionHistoryLimit: 5
+  selector:
+    matchLabels:
+      app: keycloak
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: keycloak
+      name: keycloak
+      annotations:
+        ndc.istat.it/realm-seed-revision: "3-realm-roles-mapper"
+    spec:
+      containers:
+        - name: keycloak
+          image: quay.io/keycloak/keycloak:26.1
+          imagePullPolicy: IfNotPresent
+          args:
+            - start
+            - --import-realm
+          env:
+            - name: KC_DB
+              value: dev-file
+            - name: KC_HOSTNAME
+              value: https://keycloak-ndc-test.apps.cloudpub.testedev.istat.it
+            - name: KC_HOSTNAME_STRICT_HTTPS
+              value: "false"
+            - name: KC_HTTP_ENABLED
+              value: "true"
+            - name: KC_PROXY_HEADERS
+              value: xforwarded
+            - name: KC_HEALTH_ENABLED
+              value: "true"
+            - name: KC_LOG_LEVEL
+              value: INFO
+            - name: KC_BOOTSTRAP_ADMIN_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: keycloak-admin-test
+                  key: KEYCLOAK_ADMIN
+            - name: KC_BOOTSTRAP_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: keycloak-admin-test
+                  key: KEYCLOAK_ADMIN_PASSWORD
+            - name: BFF_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: admin-oauth-test
+                  key: client-secret
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+            - name: management
+              containerPort: 9000
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /health/live
+              port: 9000
+              scheme: HTTP
+            initialDelaySeconds: 120
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health/ready
+              port: 9000
+              scheme: HTTP
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+            requests:
+              cpu: 250m
+              memory: 384Mi
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - name: realm-import
+              mountPath: /opt/keycloak/data/import
+              readOnly: true
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - name: realm-import
+          configMap:
+            name: keycloak-realm-seed

--- a/keycloak/route.yaml
+++ b/keycloak/route.yaml
@@ -1,0 +1,20 @@
+---
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: keycloak
+  namespace: ndc-test
+  labels:
+    app: keycloak
+spec:
+  host: keycloak-ndc-test.apps.cloudpub.testedev.istat.it
+  to:
+    kind: Service
+    name: keycloak
+    weight: 100
+  port:
+    targetPort: 8080
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+  wildcardPolicy: None

--- a/keycloak/service.yaml
+++ b/keycloak/service.yaml
@@ -1,0 +1,17 @@
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: keycloak
+  namespace: ndc-test
+  labels:
+    app: keycloak
+spec:
+  ports:
+    - name: http
+      protocol: TCP
+      port: 8080
+      targetPort: 8080
+  selector:
+    app: keycloak
+  sessionAffinity: None


### PR DESCRIPTION
## Summary
- Bump backend, lode, lodview, webvowl to latest images (align with ndc-dev)
- Add dati-semantic-admin and keycloak deployments for ndc-test (porting from ndc-dev)

## Image changes
| Module | From | To |
|--------|------|----|
| backend | 20250922-520-387766a | 20260624-548-dea84a6 |
| lode | 20251212-32-7c632b6 | 20260414-42-d55c02c |
| lodview | 20250704-127-913191b | 20260414-134-5605877 |
| webvowl | 20230210-18-2c46742 | 20260217-22-3c91ef3 |
| admin | (new) | 20260624-17-fee1b65 |
| keycloak | (new) | 26.1 |

## New secrets required in ndc-test namespace
- `admin-oauth-test` (key: `client-secret`) — OAuth2 client secret for ndc-admin-bff-client
- `keycloak-admin-test` (keys: `KEYCLOAK_ADMIN`, `KEYCLOAK_ADMIN_PASSWORD`) — Keycloak bootstrap admin credentials