### PR TITLE
bump backend/lode/lodview/webvowl to latest images (prod)

### DIFF
--- a/dati-semantic-backend/deployment.yaml
+++ b/dati-semantic-backend/deployment.yaml
@@ -95,7 +95,7 @@ spec:
               value: 'true'
             - name: JAVA_MAIL_DEBUG
               value: 'false'
-          image: ghcr.io/teamdigitale/dati-semantic-backend:20250922-520-387766a
+          image: ghcr.io/teamdigitale/dati-semantic-backend:20260624-548-dea84a6
           imagePullPolicy: Always
           livenessProbe:
             failureThreshold: 3

--- a/dati-semantic-lode/deployment.yaml
+++ b/dati-semantic-lode/deployment.yaml
@@ -29,7 +29,7 @@ spec:
               value: "/lode"
             - name: WEBVOWL_URL
               value: "/webvowl/#iri="
-          image: ghcr.io/teamdigitale/dati-semantic-lode:20230210-21-f8d6926
+          image: ghcr.io/teamdigitale/dati-semantic-lode:20260414-42-d55c02c
           imagePullPolicy: Always
           name: dati-semantic-lode
           ports:

--- a/dati-semantic-lodview/deployment.yaml
+++ b/dati-semantic-lodview/deployment.yaml
@@ -43,7 +43,7 @@ spec:
               value: "/lodview/staticResources/"
             - name: LodViewpublicUrlPrefix
               value: "/lodview/"
-          image: ghcr.io/teamdigitale/dati-semantic-lodview:20250704-127-913191b
+          image: ghcr.io/teamdigitale/dati-semantic-lodview:20260414-134-5605877
           imagePullPolicy: Always
           name: dati-semantic-lodview
           livenessProbe:

--- a/dati-semantic-webvowl/deployment.yaml
+++ b/dati-semantic-webvowl/deployment.yaml
@@ -29,7 +29,7 @@ spec:
               value: "/webvowl"
             - name: ONTOLOGY_URL
               value: "/onto"
-          image: ghcr.io/teamdigitale/dati-semantic-webvowl:20230210-18-2c46742
+          image: ghcr.io/teamdigitale/dati-semantic-webvowl:20260217-22-3c91ef3
           imagePullPolicy: Always
           name: dati-semantic-webvowl
           ports:


### PR DESCRIPTION
## Summary
- Bump backend, lode, lodview, webvowl to latest images (align with ndc-dev/ndc-test)

## Image changes
| Module | From | To |
|--------|------|----|
| backend | 20250922-520-387766a | 20260624-548-dea84a6 |
| lode | 20230210-21-f8d6926 | 20260414-42-d55c02c |
| lodview | 20250704-127-913191b | 20260414-134-5605877 |
| webvowl | 20230210-18-2c46742 | 20260217-22-3c91ef3 |