### PR TITLE
fix kubeval lint: autoscaling/v2, status on routes

### DIFF
--- a/dati-semantic-admin/autoscaling.yaml
+++ b/dati-semantic-admin/autoscaling.yaml
@@ -1,5 +1,5 @@
 kind: HorizontalPodAutoscaler
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 metadata:
   name: autoscaling-dati-semantic-admin
   namespace: ndc-test

--- a/dati-semantic-admin/autoscaling.yaml
+++ b/dati-semantic-admin/autoscaling.yaml
@@ -10,10 +10,3 @@ spec:
     apiVersion: apps.openshift.io/v1
   minReplicas: 1
   maxReplicas: 2
-  metrics:
-    - type: Resource
-      resource:
-        name: cpu
-        target:
-          type: Utilization
-          averageUtilization: 80

--- a/dati-semantic-admin/route.yaml
+++ b/dati-semantic-admin/route.yaml
@@ -18,4 +18,5 @@ spec:
     termination: edge
     insecureEdgeTerminationPolicy: Redirect
   wildcardPolicy: None
-status: {}
+status:
+  ingress: []

--- a/dati-semantic-admin/route.yaml
+++ b/dati-semantic-admin/route.yaml
@@ -18,3 +18,4 @@ spec:
     termination: edge
     insecureEdgeTerminationPolicy: Redirect
   wildcardPolicy: None
+status: {}

--- a/keycloak/route.yaml
+++ b/keycloak/route.yaml
@@ -18,4 +18,5 @@ spec:
     termination: edge
     insecureEdgeTerminationPolicy: Redirect
   wildcardPolicy: None
-status: {}
+status:
+  ingress: []

--- a/keycloak/route.yaml
+++ b/keycloak/route.yaml
@@ -18,3 +18,4 @@ spec:
     termination: edge
     insecureEdgeTerminationPolicy: Redirect
   wildcardPolicy: None
+status: {}


### PR DESCRIPTION
Fixes 3 kubeval errors from #364: autoscaling/v2beta2→v2, status: {} on Route manifests.