### PR TITLE
Configure backend OAuth2 issuer for ndc-test

### DIFF
--- a/dati-semantic-backend/deployment.yaml
+++ b/dati-semantic-backend/deployment.yaml
@@ -99,6 +99,10 @@ spec:
               value: "true"
             - name: JAVA_MAIL_DEBUG
               value: "true"
+            - name: MANAGEMENT_HEALTH_MAIL_ENABLED
+              value: "false"
+            - name: OAUTH2_ISSUER_URI
+              value: https://keycloak-ndc-test.apps.cloudpub.testedev.istat.it/realms/ndc
           image: ghcr.io/teamdigitale/dati-semantic-backend:20260624-548-dea84a6
           imagePullPolicy: Always
           livenessProbe:


### PR DESCRIPTION
The ndc-test backend was missing `OAUTH2_ISSUER_URI`, so its JwtDecoder fell back to `http://localhost:8082/realms/ndc` and every authenticated call from the admin panel failed with `Connection refused` (surfaced as 5xx / "backend DOWN").

- Set `OAUTH2_ISSUER_URI` to the test Keycloak realm so the backend validates the panel's tokens (mirrors the dev config).
- Disable the mail health indicator (`MANAGEMENT_HEALTH_MAIL_ENABLED=false`) to keep `/status` responsive, same as dev.