### PR TITLE
chore(test): bump dati-semantic-backend a 20260703-550-6a2b717

### DIFF
--- a/dati-semantic-backend/deployment.yaml
+++ b/dati-semantic-backend/deployment.yaml
@@ -103,7 +103,7 @@ spec:
               value: "false"
             - name: OAUTH2_ISSUER_URI
               value: https://keycloak-ndc-test.apps.cloudpub.testedev.istat.it/realms/ndc
-          image: ghcr.io/teamdigitale/dati-semantic-backend:20260624-548-dea84a6
+          image: ghcr.io/teamdigitale/dati-semantic-backend:20260703-550-6a2b717
           imagePullPolicy: Always
           livenessProbe:
             failureThreshold: 3


### PR DESCRIPTION
Aggiorna l'immagine del backend su **test** a `20260703-550-6a2b717` (già live e verificata su dev).

Include il fix della dashboard stats (backend PR [#191](https://github.com/teamdigitale/dati-semantic-backend/pull/191)): la view `LATEST_HARVESTER_RUN_BY_YEAR` ora considera solo run `SUCCESS`, così un harvest `UNCHANGED` non azzera più le statistiche.

Su dev il nuovo pod è Ready e Flyway ha applicato la migration V16 (`now at version v16`).

> Merge in **squash** (i merge commit che modificano manifest esistenti vengono saltati dalla pipeline).