### PR TITLE
Update container image version in deployment.yaml (backend, ndc-test)

### DIFF
--- a/dati-semantic-backend/deployment.yaml
+++ b/dati-semantic-backend/deployment.yaml
@@ -103,7 +103,7 @@ spec:
               value: "false"
             - name: OAUTH2_ISSUER_URI
               value: https://keycloak-ndc-test.apps.cloudpub.testedev.istat.it/realms/ndc
-          image: ghcr.io/teamdigitale/dati-semantic-backend:20260703-550-6a2b717
+          image: ghcr.io/teamdigitale/dati-semantic-backend:20260805-552-1e291d1
           imagePullPolicy: Always
           livenessProbe:
             failureThreshold: 3


### PR DESCRIPTION
Allinea `dati-semantic-backend` su `ndc-test` all'immagine `20260805-552-1e291d1`, gia' in esecuzione su `ndc-dev`.

```diff
- image: ghcr.io/teamdigitale/dati-semantic-backend:20260703-550-6a2b717
+ image: ghcr.io/teamdigitale/dati-semantic-backend:20260805-552-1e291d1
```

L'immagine contiene teamdigitale/dati-semantic-backend#193, che corregge `GET /dashboard/aggregated-count-data`: i conteggi consideravano l'ultimo harvest di ogni repository a prescindere dallo stato, e un run `UNCHANGED` (harvest periodico senza revisioni nuove) non scrive statistiche, quindi la dashboard "I numeri del catalogo" si svuotava.

Oggi su `ndc-test` l'effetto e' visibile, mentre su `ndc-dev`, gia' aggiornato, e' rientrato:

| anno | ndc-test (`550-6a2b717`) | ndc-dev (`552-1e291d1`) |
|---|---|---|
| 2025 | 0 | 301 |
| 2026 | 0 | 325 |

Su `ndc-dev` il totale 2026 coincide con `semantic-assets/stats?year=2026`, quindi grafici e riquadri numerici sono di nuovo allineati.

Nessuna modifica oltre al tag: il resto del descrittore e' invariato.